### PR TITLE
Update CI scripts

### DIFF
--- a/.scripts/setup_lua.sh
+++ b/.scripts/setup_lua.sh
@@ -11,7 +11,7 @@ set -eufo pipefail
 LUAJIT_VERSION="2.0.4"
 LUAJIT_BASE="LuaJIT-$LUAJIT_VERSION"
 
-source .travis/platform.sh
+source .scripts/platform.sh
 
 LUA_HOME_DIR=$TRAVIS_BUILD_DIR/install/lua
 

--- a/.scripts/setup_lua.sh
+++ b/.scripts/setup_lua.sh
@@ -8,9 +8,10 @@
 
 set -eufo pipefail
 
-LUAJIT_BASE="LuaJIT-2.0.4"
+LUAJIT_VERSION="2.0.4"
+LUAJIT_BASE="LuaJIT-$LUAJIT_VERSION"
 
-source .scripts/platform.sh
+source .travis/platform.sh
 
 LUA_HOME_DIR=$TRAVIS_BUILD_DIR/install/lua
 
@@ -39,9 +40,9 @@ mkdir -p "$LUA_HOME_DIR"
 if [ "$LUAJIT" == "yes" ]; then
 
   if [ "$LUA" == "luajit" ]; then
-    curl http://luajit.org/download/$LUAJIT_BASE.tar.gz | tar xz;
+    curl --location https://github.com/LuaJIT/LuaJIT/archive/v$LUAJIT_VERSION.tar.gz | tar xz;
   else
-    git clone http://luajit.org/git/luajit-2.0.git $LUAJIT_BASE;
+    git clone https://github.com/LuaJIT/LuaJIT.git $LUAJIT_BASE;
   fi
 
   cd $LUAJIT_BASE
@@ -66,8 +67,8 @@ else
     curl http://www.lua.org/ftp/lua-5.2.4.tar.gz | tar xz
     cd lua-5.2.4;
   elif [ "$LUA" == "lua5.3" ]; then
-    curl http://www.lua.org/ftp/lua-5.3.1.tar.gz | tar xz
-    cd lua-5.3.1;
+    curl http://www.lua.org/ftp/lua-5.3.2.tar.gz | tar xz
+    cd lua-5.3.2;
   fi
 
   # Build Lua without backwards compatibility for testing
@@ -117,5 +118,5 @@ elif [ "$LUA" == "lua5.1" ]; then
 elif [ "$LUA" == "lua5.2" ]; then
   rm -rf lua-5.2.4;
 elif [ "$LUA" == "lua5.3" ]; then
-  rm -rf lua-5.3.1;
+  rm -rf lua-5.3.2;
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 
 env:
   global:
-    - LUAROCKS=2.2.2
+    - LUAROCKS=2.3.0
   matrix:
     - LUA=lua5.1
     - LUA=lua5.2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,14 +7,14 @@ version: 0.1.0.{build}
 shallow_clone: true
 
 environment:
-  LUAROCKS_VER: HEAD
+  LUAROCKS_VER: 2.3.0
   matrix:
   - LUA_VER: 5.1.5
 #  - LUA_VER: 5.2.4  # Lua 5.2.4 with compatibility flags enabled (DLUA_COMPAT_ALL).
   - LUA_VER: 5.2.4  # Lua 5.2.4 with compatibility flags disabled.
     NOCOMPAT: true
-#  - LUA_VER: 5.3.1  # Lua 5.3.1 with compatibility flags enabled (DLUA_COMPAT_5_2).
-  - LUA_VER: 5.3.1  # Lua 5.3.1 with compatibility flags disabled.
+#  - LUA_VER: 5.3.2  # Lua 5.3.2 with compatibility flags enabled (DLUA_COMPAT_5_2).
+  - LUA_VER: 5.3.2  # Lua 5.3.2 with compatibility flags disabled.
     NOCOMPAT: true
   - LJ_VER: 2.0.4
   - LJ_VER: 2.1
@@ -27,7 +27,7 @@ matrix:
 # Abuse this section so we can have a matrix with different Compiler versions
 # Is there a better way? Like injecting an array in the matrix?
 configuration:
-# - 2015 # disabled until LuaRocks supports it officially
+  - 2015
   - 2013
 #  - MinGW
 


### PR DESCRIPTION
A number of changes were introduced in the CI scripts for both Travis and AppVeyor:

- Use LuaRocks 2.3.0 (mostly for CMake 64 bits support)
- Fix issue with LuaJIT ban.
- Enables compilation with VS 2015 too (AppVeyor)

However, I'm now seeing failures in a test for LuaJIT (2.0.4 and 2.1) and Lua 5.2

~~~
Failure → spec/json_encode_spec.lua @ 16
rapidjson.encode() should detect integers
spec/json_encode_spec.lua:18: Expected objects to be equal.
Passed in:
(string) '-0.0'
Expected:
(string) '0.0'
~~~