### PR TITLE
Wrap JSON Schema validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ json.so
 json.dll
 deps/
 /*.src.rock
+rapidjson.so

--- a/README.md
+++ b/README.md
@@ -252,6 +252,49 @@ rapidjson.dump({rapidjson.null}, 'test-pretty.json', {pretty=true})
 
 ```
 
+### rapidjson.schema_validate()
+
+Validates whether a JSON document obeys a specified JSON Schema.
+
+#### Synopsis
+
+```Lua
+object = rapidjson.schema_validate(schema, document)
+```
+
+#### Arguments
+
+**schema**:
+
+A string with the JSON Schema.
+
+**document**:
+
+The document to be validated.
+
+#### Returns
+
+Return `false` when the document doesn't validate against the schema.
+
+Return the decoded document (i.e. a Lua table) if the document validates against
+the schema.
+
+#### Errors
+
+* When the `schema` parameter isn't a valid JSON document.
+* When the `document` parameter isn't a valid JSON document.
+
+#### Examples
+
+```Lua
+local rapidjson = require('rapidjson')
+
+rapidjson.schema_validate(
+    '{ "$schema": "http://json-schema.org/draft-04/schema#", "type": "object", "properties": { "q": { "type": "string" } }, "required": [ "q" ] }',
+    '{"q": "a value"}'
+)
+```
+
 ### rapidjson.null
 
 The placeholder for null values in rapidjson.

--- a/spec/schema_validate_spec.lua
+++ b/spec/schema_validate_spec.lua
@@ -1,0 +1,101 @@
+--luacheck: ignore describe it
+describe('rapidjson.schema_validate()', function()
+  local rapidjson = require('rapidjson')
+
+  simple_valid_schema = [[
+    {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": { "q": { "type": "string" } },
+    "required": [ "q" ]
+    }
+    ]]
+
+  simple_invalid_schema = [[
+    {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": { "q": { "type": "string" } },
+    "required": [ "q" ]
+    ]]
+
+  complex_schema = [[
+    {
+      "required": ["name", "age", "email", "foo", "bar"],
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "id": "DataTypes.User",
+      "title": "DataTypes.User",
+      "type": "object",
+      "definitions": {
+        "DataTypes.X": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "id": "",
+          "title": "DataTypes.X",
+          "enum": ["P", "R"]
+        },
+        "DataTypes.Q": {
+          "required": ["baz"],
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "id": "",
+          "title": "DataTypes.Q",
+          "type": "object",
+          "properties": {"baz": {"$ref": "#/definitions/DataTypes.Z"}}
+        },
+        "DataTypes.Z": {
+          "required": ["quux"],
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "id": "",
+          "title": "DataTypes.Z",
+          "type": "object",
+          "properties": {"quux": {"$ref": "#/definitions/DataTypes.X"}}
+        }
+      },
+      "properties": {
+        "email": {"type": ["string", "null"]},
+        "age": {"type": "integer"},
+        "foo": {"$ref": "#/definitions/DataTypes.Q"},
+        "name": {"type": "string"},
+        "bar": {"$ref": "#/definitions/DataTypes.Z"}
+      }
+    }
+    ]]
+
+  complex_document = [[
+    {
+      "name": "John Doe",
+      "age": 23,
+      "email": null,
+      "foo": {"baz": {"quux": "P"}},
+      "bar": {"quux": "R"}
+    }
+    ]]
+
+  it('should properly validate against a simple schema', function()
+    t = rapidjson.schema_validate(simple_valid_schema, '{"q": "blah"}')
+    assert.is_table(t)
+    assert.are.equal(t['q'], 'blah')
+
+    -- shouldn't validate -- `q` is not a string
+    t = rapidjson.schema_validate(simple_valid_schema, '{"q": 3}')
+    assert.is_not_table(t)
+    assert.is_not_true(t)
+  end)
+
+  it('should raise an error when the document is invalid JSON', function()
+    assert.has_error(function()
+      rapidjson.schema_validate(simple_valid_schema, '{"q":}')
+    end)
+  end)
+
+  it('should raise an error when the schema is invalid JSON', function()
+    assert.has_error(function()
+      rapidjson.schema_validate(simple_invalid_schema,'{"q":"blah"}')
+    end)
+  end)
+
+  it('should properly work on a real-world schema', function()
+    t = rapidjson.schema_validate(complex_schema, complex_document)
+    assert.is_table(t)
+    assert.are.equal(t['name'], 'John Doe')
+  end)
+end)

--- a/src/rapidjson.cpp
+++ b/src/rapidjson.cpp
@@ -24,6 +24,7 @@
 #include "rapidjson/filewritestream.h"
 #include "rapidjson/rapidjson.h"
 #include "rapidjson/reader.h"
+#include "rapidjson/schema.h"
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 #include "rapidjson/prettywriter.h"
@@ -33,6 +34,10 @@ using namespace rapidjson;
 #ifndef LUA_RAPIDJSON_VERSION
 #define LUA_RAPIDJSON_VERSION "scm"
 #endif
+
+// -----------------------------------------------------------------------------
+// INFRASTRUCTURE
+// -----------------------------------------------------------------------------
 
 static const char* JSON_TABLE_TYPE_FIELD = "__jsontype";
 enum json_table_type {
@@ -145,6 +150,9 @@ static int json_array(lua_State* L)
 	return makeTableType(L, 1, JSON_TABLE_TYPE_ARRAY);
 }
 
+// -----------------------------------------------------------------------------
+// DECODE
+// -----------------------------------------------------------------------------
 
 struct Ctx {
 	Ctx() : fn_(&topFn){}
@@ -191,6 +199,7 @@ private:
 	}
 };
 
+// http://rapidjson.org/md_doc_sax.html#Reader
 struct ToLuaHandler {
 	ToLuaHandler(lua_State* aL) : L(aL) { stack_.reserve(32); }
 
@@ -333,6 +342,10 @@ static int json_load(lua_State* L)
 	return n;
 }
 
+// -----------------------------------------------------------------------------
+// ENCODE
+// -----------------------------------------------------------------------------
+
 struct Key
 {
 	Key(const char* k, SizeType l) : key(k), size(l) {}
@@ -345,7 +358,7 @@ struct Key
 
 
 
-
+// http://rapidjson.org/md_doc_sax.html#Writer
 class Encoder {
 	bool pretty;
 	bool sort_keys;
@@ -655,6 +668,64 @@ static int json_dump(lua_State* L)
 	return 0;
 }
 
+// -----------------------------------------------------------------------------
+// JSON SCHEMA VALIDATION
+// -----------------------------------------------------------------------------
+
+// http://rapidjson.org/md_doc_schema.html
+class JSONSchemaValidator
+{
+	const char* schema;
+	const char* json_document;
+
+public:
+	JSONSchemaValidator(const char* scm, const char* doc)
+		: schema(scm), json_document(doc) {}
+
+	bool validate(lua_State* L)
+	{
+		Document sd;
+		if (sd.Parse(schema).HasParseError()) {
+			return luaL_error(L, "The JSON Schema is not a valid JSON document.");
+		}
+
+		SchemaDocument schema_doc(sd);
+		SchemaValidator validator(schema_doc);
+		Document d;
+
+		if (d.Parse(json_document).HasParseError()) {
+			return luaL_error(L, "Invalid JSON document.");
+		}
+
+		if (!d.Accept(validator)) {
+			return false;
+		}
+
+		return true;
+	}
+};
+
+static int schema_validate(lua_State* L)
+{
+	const char* scm = luaL_checkstring(L, 1);
+	const char* doc = luaL_checkstring(L, 2);
+
+	JSONSchemaValidator* validator = new JSONSchemaValidator(scm, doc);
+
+	if (validator->validate(L)) {
+		StringStream s(doc);
+		return decode(L, &s);
+	}
+
+	lua_pushboolean(L, false);
+
+	delete validator;
+	return 1;
+}
+
+// -----------------------------------------------------------------------------
+// LUA MODULE INFRASTRUCTURE
+// -----------------------------------------------------------------------------
 
 static const luaL_Reg methods[] = {
 	// string <--> json
@@ -664,6 +735,9 @@ static const luaL_Reg methods[] = {
 	// file <--> json
 	{ "load", json_load },
 	{ "dump", json_dump },
+
+  // schema
+	{ "schema_validate", schema_validate },
 
 	// special tags place holder
 	{ "null", json_null },


### PR DESCRIPTION
Expose a new function, `schema_validate`, which accepts two parameters:
the schema (a string) and the JSON document (a string).

Instead of returning simple true/false, return:
- false if the document doesn't match the schema;
- the decoded Lua table of the document if the document matches the
  schema.
